### PR TITLE
Fix dynamic route param handling

### DIFF
--- a/src/app/api/inventory/[id]/route.ts
+++ b/src/app/api/inventory/[id]/route.ts
@@ -1,12 +1,12 @@
 // src/app/api/inventory/[id]/route.ts
 
-import { NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 import { PrismaClient, Prisma } from '@prisma/client';
 
 const prisma = new PrismaClient();
 
 // PATCH: Update a core inventory item's details with robust validation
-export async function PATCH(request: Request, { params }: { params: { id: string } }) {
+export async function PATCH(request: NextRequest, { params }: { params: { id: string } }) {
   try {
     const itemId = Number(params.id);
     if (isNaN(itemId)) {
@@ -91,7 +91,7 @@ export async function PATCH(request: Request, { params }: { params: { id: string
 }
 
 // DELETE: Delete an inventory item
-export async function DELETE(request: Request, { params }: { params: { id: string } }) {
+export async function DELETE(request: NextRequest, { params }: { params: { id: string } }) {
   try {
     const itemId = Number(params.id);
     if (isNaN(itemId)) {

--- a/src/app/api/inventory/[id]/route.ts
+++ b/src/app/api/inventory/[id]/route.ts
@@ -6,11 +6,9 @@ import { PrismaClient, Prisma } from '@prisma/client';
 const prisma = new PrismaClient();
 
 // PATCH: Update a core inventory item's details with robust validation
-export async function PATCH(request: Request, { params }: { params: Promise<{ id: string }> }) {
+export async function PATCH(request: Request, { params }: { params: { id: string } }) {
   try {
-    // --- FIXED: Await params before accessing properties ---
-    const resolvedParams = await params;
-    const itemId = Number(resolvedParams.id);
+    const itemId = Number(params.id);
     if (isNaN(itemId)) {
       return NextResponse.json({ error: 'Invalid item ID.' }, { status: 400 });
     }
@@ -93,11 +91,9 @@ export async function PATCH(request: Request, { params }: { params: Promise<{ id
 }
 
 // DELETE: Delete an inventory item
-export async function DELETE(request: Request, { params }: { params: Promise<{ id: string }> }) {
+export async function DELETE(request: Request, { params }: { params: { id: string } }) {
   try {
-    // --- FIXED: Await params before accessing properties ---
-    const resolvedParams = await params;
-    const itemId = Number(resolvedParams.id);
+    const itemId = Number(params.id);
     if (isNaN(itemId)) {
       return NextResponse.json({ error: 'Invalid item ID.' }, { status: 400 });
     }

--- a/src/app/api/orders/[id]/complete/route.ts
+++ b/src/app/api/orders/[id]/complete/route.ts
@@ -8,11 +8,10 @@ const prisma = new PrismaClient();
 // PATCH: Mark an order as completed and clean up special prices if it's the last one for a customer
 export async function PATCH(
   request: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
+  { params }: { params: { id: string } }
 ) {
   try {
-    const { id } = await params; // Await the params Promise
-    const orderId = Number(id);
+    const orderId = Number(params.id);
 
     await prisma.$transaction(async (tx) => {
       // Step 1: Find the order to get the customer's name.

--- a/src/app/api/orders/[id]/route.ts
+++ b/src/app/api/orders/[id]/route.ts
@@ -6,10 +6,9 @@ import { PrismaClient } from '@prisma/client';
 const prisma = new PrismaClient();
 
 // PUT: Edit an existing order with a hard, date-based stock check
-export async function PUT(request: Request, { params }: { params: Promise<{ id: string }> }) {
+export async function PUT(request: Request, { params }: { params: { id: string } }) {
   try {
-    const { id } = await params;
-    const orderId = Number(id);
+    const orderId = Number(params.id);
     const data = await request.json();
     const { customerName, deposit, pickUpDate, deliveryDate, items: newItems } = data;
 
@@ -80,10 +79,9 @@ export async function PUT(request: Request, { params }: { params: Promise<{ id: 
 }
 
 // DELETE: Delete an active order and clean up special prices if it's the last one for a customer
-export async function DELETE(request: Request, { params }: { params: Promise<{ id: string }> }) {
+export async function DELETE(request: Request, { params }: { params: { id: string } }) {
   try {
-    const { id } = await params;
-    const orderId = Number(id);
+    const orderId = Number(params.id);
 
     await prisma.$transaction(async (tx) => {
       // Step 1: Find the order to get the customer's name before deleting it.

--- a/src/app/api/orders/[id]/route.ts
+++ b/src/app/api/orders/[id]/route.ts
@@ -1,12 +1,12 @@
 // src/app/api/orders/[id]/route.ts
 
-import { NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 import { PrismaClient } from '@prisma/client';
 
 const prisma = new PrismaClient();
 
 // PUT: Edit an existing order with a hard, date-based stock check
-export async function PUT(request: Request, { params }: { params: { id: string } }) {
+export async function PUT(request: NextRequest, { params }: { params: { id: string } }) {
   try {
     const orderId = Number(params.id);
     const data = await request.json();
@@ -79,7 +79,7 @@ export async function PUT(request: Request, { params }: { params: { id: string }
 }
 
 // DELETE: Delete an active order and clean up special prices if it's the last one for a customer
-export async function DELETE(request: Request, { params }: { params: { id: string } }) {
+export async function DELETE(request: NextRequest, { params }: { params: { id: string } }) {
   try {
     const orderId = Number(params.id);
 

--- a/src/app/api/packages/[id]/route.ts
+++ b/src/app/api/packages/[id]/route.ts
@@ -1,10 +1,10 @@
 // src/app/api/packages/[id]/route.ts
-import { NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 import { PrismaClient } from '@prisma/client';
 
 const prisma = new PrismaClient();
 
-export async function GET(request: Request, { params }: { params: { id: string } }) {
+export async function GET(request: NextRequest, { params }: { params: { id: string } }) {
   const parsedId = parseInt(params.id, 10);
   if (isNaN(parsedId)) {
     return NextResponse.json({ error: 'Invalid package ID' }, { status: 400 });
@@ -33,7 +33,7 @@ export async function GET(request: Request, { params }: { params: { id: string }
   }
 }
 
-export async function DELETE(request: Request, { params }: { params: { id: string } }) {
+export async function DELETE(request: NextRequest, { params }: { params: { id: string } }) {
   const parsedId = parseInt(params.id, 10);
   if (isNaN(parsedId)) {
     return NextResponse.json({ error: 'Invalid package ID' }, { status: 400 });

--- a/src/app/api/packages/[id]/route.ts
+++ b/src/app/api/packages/[id]/route.ts
@@ -4,9 +4,8 @@ import { PrismaClient } from '@prisma/client';
 
 const prisma = new PrismaClient();
 
-export async function GET(request: Request, { params }: { params: Promise<{ id: string }> }) {
-  const { id } = await params;
-  const parsedId = parseInt(id, 10);
+export async function GET(request: Request, { params }: { params: { id: string } }) {
+  const parsedId = parseInt(params.id, 10);
   if (isNaN(parsedId)) {
     return NextResponse.json({ error: 'Invalid package ID' }, { status: 400 });
   }
@@ -34,9 +33,8 @@ export async function GET(request: Request, { params }: { params: Promise<{ id: 
   }
 }
 
-export async function DELETE(request: Request, { params }: { params: Promise<{ id: string }> }) {
-  const { id } = await params;
-  const parsedId = parseInt(id, 10);
+export async function DELETE(request: Request, { params }: { params: { id: string } }) {
+  const parsedId = parseInt(params.id, 10);
   if (isNaN(parsedId)) {
     return NextResponse.json({ error: 'Invalid package ID' }, { status: 400 });
   }

--- a/src/app/api/special-price/[id]/route.ts
+++ b/src/app/api/special-price/[id]/route.ts
@@ -6,10 +6,9 @@ import { PrismaClient } from '@prisma/client';
 const prisma = new PrismaClient();
 
 // DELETE: Delete a special price and revert prices on active orders
-export async function DELETE(request: Request, { params }: { params: Promise<{ id: string }> }) {
+export async function DELETE(request: Request, { params }: { params: { id: string } }) {
   try {
-    const { id } = await params;
-    const specialPriceId = Number(id);
+    const specialPriceId = Number(params.id);
 
     // --- TRANSACTION START ---
     await prisma.$transaction(async (tx) => {

--- a/src/app/api/special-price/[id]/route.ts
+++ b/src/app/api/special-price/[id]/route.ts
@@ -1,12 +1,12 @@
 // src/app/api/special-price/[id]/route.ts
 
-import { NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 import { PrismaClient } from '@prisma/client';
 
 const prisma = new PrismaClient();
 
 // DELETE: Delete a special price and revert prices on active orders
-export async function DELETE(request: Request, { params }: { params: { id: string } }) {
+export async function DELETE(request: NextRequest, { params }: { params: { id: string } }) {
   try {
     const specialPriceId = Number(params.id);
 


### PR DESCRIPTION
## Summary
- correct parameter handling in API route handlers

## Testing
- `npx tsc --noEmit`
- `npm run lint` *(fails: Unexpected any errors)*

------
https://chatgpt.com/codex/tasks/task_e_6849afddcfa8832798f9a19ecbd57c0c