### PR TITLE
Refactor Prisma usage

### DIFF
--- a/src/app/api/completed-orders/route.ts
+++ b/src/app/api/completed-orders/route.ts
@@ -1,9 +1,8 @@
 // src/app/api/completed-orders/route.ts
 
 import { NextResponse } from 'next/server';
-import { PrismaClient } from '@prisma/client';
+import prisma from '@/lib/prisma';
 
-const prisma = new PrismaClient();
 
 // GET: Get all COMPLETED orders (with items and fees)
 export async function GET() {

--- a/src/app/api/inventory/[id]/route.ts
+++ b/src/app/api/inventory/[id]/route.ts
@@ -1,9 +1,9 @@
 // src/app/api/inventory/[id]/route.ts
 
 import { NextResponse } from 'next/server';
-import { PrismaClient, Prisma } from '@prisma/client';
+import { Prisma } from '@prisma/client';
+import prisma from '@/lib/prisma';
 
-const prisma = new PrismaClient();
 
 // PATCH: Update a core inventory item's details with robust validation
 export async function PATCH(request: Request, { params }: { params: Promise<{ id: string }> }) {

--- a/src/app/api/inventory/availability/route.ts
+++ b/src/app/api/inventory/availability/route.ts
@@ -1,9 +1,8 @@
 // src/app/api/inventory/availability/route.ts
 
 import { NextResponse } from 'next/server';
-import { PrismaClient } from '@prisma/client';
+import prisma from '@/lib/prisma';
 
-const prisma = new PrismaClient();
 
 // POST: Check availability for a specific item within a date range
 export async function POST(request: Request) {

--- a/src/app/api/inventory/route.ts
+++ b/src/app/api/inventory/route.ts
@@ -1,9 +1,8 @@
 // src/app/api/inventory/route.ts
 
 import { NextResponse } from 'next/server';
-import { PrismaClient } from '@prisma/client';
+import prisma from '@/lib/prisma';
 
-const prisma = new PrismaClient();
 
 // GET: Get all inventory items and dynamically calculate current stock
 export async function GET() {

--- a/src/app/api/orders/[id]/complete/route.ts
+++ b/src/app/api/orders/[id]/complete/route.ts
@@ -1,9 +1,8 @@
 // src/app/api/orders/[id]/complete/route.ts
 
 import { NextRequest, NextResponse } from 'next/server';
-import { PrismaClient } from '@prisma/client';
+import prisma from '@/lib/prisma';
 
-const prisma = new PrismaClient();
 
 // PATCH: Mark an order as completed and clean up special prices if it's the last one for a customer
 export async function PATCH(

--- a/src/app/api/orders/[id]/route.ts
+++ b/src/app/api/orders/[id]/route.ts
@@ -1,9 +1,8 @@
 // src/app/api/orders/[id]/route.ts
 
 import { NextResponse } from 'next/server';
-import { PrismaClient } from '@prisma/client';
+import prisma from '@/lib/prisma';
 
-const prisma = new PrismaClient();
 
 // PUT: Edit an existing order with a hard, date-based stock check
 export async function PUT(request: Request, { params }: { params: Promise<{ id: string }> }) {

--- a/src/app/api/orders/route.ts
+++ b/src/app/api/orders/route.ts
@@ -1,9 +1,8 @@
 // src/app/api/orders/route.ts
 
 import { NextResponse } from 'next/server';
-import { PrismaClient } from '@prisma/client';
+import prisma from '@/lib/prisma';
 
-const prisma = new PrismaClient();
 
 // GET: Get all active orders
 export async function GET() {

--- a/src/app/api/packages/[id]/route.ts
+++ b/src/app/api/packages/[id]/route.ts
@@ -1,8 +1,7 @@
 // src/app/api/packages/[id]/route.ts
 import { NextResponse } from 'next/server';
-import { PrismaClient } from '@prisma/client';
+import prisma from '@/lib/prisma';
 
-const prisma = new PrismaClient();
 
 export async function GET(request: Request, { params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;

--- a/src/app/api/packages/route.ts
+++ b/src/app/api/packages/route.ts
@@ -1,8 +1,7 @@
 // src/app/api/packages/route.ts
 import { NextResponse } from 'next/server';
-import { PrismaClient } from '@prisma/client';
+import prisma from '@/lib/prisma';
 
-const prisma = new PrismaClient();
 
 export async function GET() {
   try {

--- a/src/app/api/special-price/[id]/route.ts
+++ b/src/app/api/special-price/[id]/route.ts
@@ -1,9 +1,8 @@
 // src/app/api/special-price/[id]/route.ts
 
 import { NextResponse } from 'next/server';
-import { PrismaClient } from '@prisma/client';
+import prisma from '@/lib/prisma';
 
-const prisma = new PrismaClient();
 
 // DELETE: Delete a special price and revert prices on active orders
 export async function DELETE(request: Request, { params }: { params: Promise<{ id: string }> }) {

--- a/src/app/api/special-price/route.ts
+++ b/src/app/api/special-price/route.ts
@@ -1,9 +1,8 @@
 // src/app/api/special-price/route.ts
 
 import { NextResponse } from 'next/server';
-import { PrismaClient } from '@prisma/client';
+import prisma from '@/lib/prisma';
 
-const prisma = new PrismaClient();
 
 // GET: Get all special prices
 export async function GET() {

--- a/src/app/api/statistics/route.ts
+++ b/src/app/api/statistics/route.ts
@@ -1,8 +1,7 @@
 // src/app/api/statistics/route.ts
 import { NextResponse } from 'next/server';
-import { PrismaClient } from '@prisma/client';
+import prisma from '@/lib/prisma';
 
-const prisma = new PrismaClient();
 
 export async function GET() {
   try {

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -1,0 +1,9 @@
+import { PrismaClient } from '@prisma/client'
+
+const globalForPrisma = globalThis as unknown as { prisma?: PrismaClient }
+
+export const prisma = globalForPrisma.prisma ?? new PrismaClient()
+
+if (process.env.NODE_ENV !== 'production') globalForPrisma.prisma = prisma
+
+export default prisma


### PR DESCRIPTION
## Summary
- add shared `prisma` client helper
- use the shared client across API routes

## Testing
- `npm run lint` *(fails: Unexpected any etc.)*
- `npm install` *(fails: Can't reach database server at `localhost:5432`)*

------
https://chatgpt.com/codex/tasks/task_e_6849c50d5ca88327ac772d9a0f9eed9c