### PR TITLE
Fix API route param signature

### DIFF
--- a/src/app/api/inventory/[id]/route.ts
+++ b/src/app/api/inventory/[id]/route.ts
@@ -1,16 +1,14 @@
 // src/app/api/inventory/[id]/route.ts
 
-import { NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 import { PrismaClient, Prisma } from '@prisma/client';
 
 const prisma = new PrismaClient();
 
 // PATCH: Update a core inventory item's details with robust validation
-export async function PATCH(request: Request, { params }: { params: Promise<{ id: string }> }) {
+export async function PATCH(request: NextRequest, context: { params: { id: string } }) {
   try {
-    // --- FIXED: Await params before accessing properties ---
-    const resolvedParams = await params;
-    const itemId = Number(resolvedParams.id);
+    const itemId = Number(context.params.id);
     if (isNaN(itemId)) {
       return NextResponse.json({ error: 'Invalid item ID.' }, { status: 400 });
     }
@@ -86,18 +84,15 @@ export async function PATCH(request: Request, { params }: { params: Promise<{ id
     }
     
     console.error("Failed to update item in database:", error);
-    // Provide the actual error in the response for better debugging if it's not a known one
     const errorMessage = error instanceof Error ? error.message : 'An unknown error occurred.';
     return NextResponse.json({ error: 'Failed to update item.', details: errorMessage }, { status: 500 });
   }
 }
 
 // DELETE: Delete an inventory item
-export async function DELETE(request: Request, { params }: { params: Promise<{ id: string }> }) {
+export async function DELETE(request: NextRequest, context: { params: { id: string } }) {
   try {
-    // --- FIXED: Await params before accessing properties ---
-    const resolvedParams = await params;
-    const itemId = Number(resolvedParams.id);
+    const itemId = Number(context.params.id);
     if (isNaN(itemId)) {
       return NextResponse.json({ error: 'Invalid item ID.' }, { status: 400 });
     }

--- a/src/app/api/orders/[id]/complete/route.ts
+++ b/src/app/api/orders/[id]/complete/route.ts
@@ -8,11 +8,10 @@ const prisma = new PrismaClient();
 // PATCH: Mark an order as completed and clean up special prices if it's the last one for a customer
 export async function PATCH(
   request: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
+  context: { params: { id: string } }
 ) {
   try {
-    const { id } = await params; // Await the params Promise
-    const orderId = Number(id);
+    const orderId = Number(context.params.id);
 
     await prisma.$transaction(async (tx) => {
       // Step 1: Find the order to get the customer's name.

--- a/src/app/api/orders/[id]/route.ts
+++ b/src/app/api/orders/[id]/route.ts
@@ -1,14 +1,14 @@
 // src/app/api/orders/[id]/route.ts
 
-import { NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 import { PrismaClient } from '@prisma/client';
 
 const prisma = new PrismaClient();
 
 // PUT: Edit an existing order with a hard, date-based stock check
-export async function PUT(request: Request, { params }: { params: Promise<{ id: string }> }) {
+export async function PUT(request: NextRequest, context: { params: { id: string } }) {
   try {
-    const { id } = await params;
+    const { id } = context.params;
     const orderId = Number(id);
     const data = await request.json();
     const { customerName, deposit, pickUpDate, deliveryDate, items: newItems } = data;
@@ -80,9 +80,9 @@ export async function PUT(request: Request, { params }: { params: Promise<{ id: 
 }
 
 // DELETE: Delete an active order and clean up special prices if it's the last one for a customer
-export async function DELETE(request: Request, { params }: { params: Promise<{ id: string }> }) {
+export async function DELETE(request: NextRequest, context: { params: { id: string } }) {
   try {
-    const { id } = await params;
+    const { id } = context.params;
     const orderId = Number(id);
 
     await prisma.$transaction(async (tx) => {

--- a/src/app/api/packages/[id]/route.ts
+++ b/src/app/api/packages/[id]/route.ts
@@ -1,11 +1,11 @@
 // src/app/api/packages/[id]/route.ts
-import { NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 import { PrismaClient } from '@prisma/client';
 
 const prisma = new PrismaClient();
 
-export async function GET(request: Request, { params }: { params: Promise<{ id: string }> }) {
-  const { id } = await params;
+export async function GET(request: NextRequest, context: { params: { id: string } }) {
+  const { id } = context.params;
   const parsedId = parseInt(id, 10);
   if (isNaN(parsedId)) {
     return NextResponse.json({ error: 'Invalid package ID' }, { status: 400 });
@@ -34,8 +34,8 @@ export async function GET(request: Request, { params }: { params: Promise<{ id: 
   }
 }
 
-export async function DELETE(request: Request, { params }: { params: Promise<{ id: string }> }) {
-  const { id } = await params;
+export async function DELETE(request: NextRequest, context: { params: { id: string } }) {
+  const { id } = context.params;
   const parsedId = parseInt(id, 10);
   if (isNaN(parsedId)) {
     return NextResponse.json({ error: 'Invalid package ID' }, { status: 400 });

--- a/src/app/api/special-price/[id]/route.ts
+++ b/src/app/api/special-price/[id]/route.ts
@@ -1,14 +1,14 @@
 // src/app/api/special-price/[id]/route.ts
 
-import { NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 import { PrismaClient } from '@prisma/client';
 
 const prisma = new PrismaClient();
 
 // DELETE: Delete a special price and revert prices on active orders
-export async function DELETE(request: Request, { params }: { params: Promise<{ id: string }> }) {
+export async function DELETE(request: NextRequest, context: { params: { id: string } }) {
   try {
-    const { id } = await params;
+    const { id } = context.params;
     const specialPriceId = Number(id);
 
     // --- TRANSACTION START ---


### PR DESCRIPTION
## Summary
- update API routes to use explicit context parameter for route params
- adjust imports to use `NextRequest`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849c9107f94832783edbe2a79588e30