### PR TITLE
Add order dashboard and contact fields

### DIFF
--- a/src/app/current-orders/page.tsx
+++ b/src/app/current-orders/page.tsx
@@ -66,6 +66,8 @@ export default function CurrentOrdersPage() {
   const [editingOrderId, setEditingOrderId] = useState<number | null>(null);
   const [customerName, setCustomerName] = useState('');
   const [deposit, setDeposit] = useState('');
+  const [phone, setPhone] = useState('');
+  const [email, setEmail] = useState('');
   const [finalPrice, setFinalPrice] = useState('');
   const [pickUpDate, setPickUpDate] = useState('');
   const [deliveryDate, setDeliveryDate] = useState('');
@@ -88,6 +90,8 @@ export default function CurrentOrdersPage() {
     setEditingOrderId(null);
     setCustomerName('');
     setDeposit('');
+    setPhone('');
+    setEmail('');
     setFinalPrice('');
     setPickUpDate('');
     setDeliveryDate('');
@@ -318,6 +322,17 @@ export default function CurrentOrdersPage() {
                     <div className="space-y-2"><label htmlFor="deposit" className={labelStyle}>Deposit (kr)</label><input id="deposit" className={inputStyle} value={deposit} onChange={e => setDeposit(e.target.value)} type="number" min={0} placeholder="0"/></div>
                     <div className="space-y-2"><label htmlFor="pickUpDate" className={labelStyle}>Pick-up Date</label><input id="pickUpDate" className={`${inputStyle} dark:[color-scheme:dark]`} type="date" value={pickUpDate} onChange={e => setPickUpDate(e.target.value)} /></div>
                     <div className="space-y-2"><label htmlFor="deliveryDate" className={labelStyle}>Delivery Date</label><input id="deliveryDate" className={`${inputStyle} dark:[color-scheme:dark]`} type="date" value={deliveryDate} onChange={e => setDeliveryDate(e.target.value)} /></div>
+                  </div>
+
+                  <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mb-6">
+                    <div className="space-y-2">
+                      <label htmlFor="phone" className={labelStyle}>Phone</label>
+                      <input id="phone" className={inputStyle} value={phone} onChange={e => setPhone(e.target.value)} placeholder="Phone number" />
+                    </div>
+                    <div className="space-y-2">
+                      <label htmlFor="email" className={labelStyle}>Email</label>
+                      <input id="email" className={inputStyle} type="email" value={email} onChange={e => setEmail(e.target.value)} placeholder="Email" />
+                    </div>
                   </div>
                   
                   <div className="mt-4 border-t border-slate-700 pt-4 grid grid-cols-1 md:grid-cols-2 gap-x-8 gap-y-6">

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,0 +1,111 @@
+'use client';
+import React, { useState, useEffect } from 'react';
+
+interface OrderItem {
+  itemName: string | null;
+  quantity: number;
+}
+interface Order {
+  id: number;
+  customerName: string;
+  pickUpDate: string;
+  deliveryDate: string;
+  items: OrderItem[];
+}
+
+export default function DashboardPage() {
+  const [orders, setOrders] = useState<Order[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    fetch('/api/orders')
+      .then(res => res.json())
+      .then(data => {
+        const transformed = data.map((o: any) => ({
+          ...o,
+          pickUpDate: o.pickUpDate.slice(0, 10),
+          deliveryDate: o.deliveryDate.slice(0, 10),
+          items: o.items.map((it: any) => ({ itemName: it.itemName || it.inventoryItem?.name || 'Deleted Item', quantity: it.quantity })),
+        }));
+        setOrders(transformed);
+        setLoading(false);
+      });
+  }, []);
+
+  const today = new Date();
+  today.setHours(0,0,0,0);
+  const fiveDaysLater = new Date(today);
+  fiveDaysLater.setDate(today.getDate() + 5);
+
+  const isBetween = (dateStr: string, start: Date, end: Date) => {
+    const d = new Date(dateStr + 'T00:00:00');
+    return d >= start && d <= end;
+  };
+
+  const ordersOut = orders.filter(o => new Date(o.pickUpDate) <= today && new Date(o.deliveryDate) >= today);
+  const upcomingOrders = orders.filter(o => new Date(o.pickUpDate) > today && isBetween(o.pickUpDate, today, fiveDaysLater));
+  const upcomingReturns = orders.filter(o => new Date(o.deliveryDate) >= today && isBetween(o.deliveryDate, today, fiveDaysLater));
+
+  const sectionClass = 'bg-slate-800/70 backdrop-blur-sm rounded-2xl border border-slate-700/50 shadow-xl p-6';
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-slate-900 via-indigo-900 to-purple-900 text-slate-200">
+      <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12 space-y-8">
+        <div className="text-center mb-8">
+          <h1 className="text-4xl font-bold text-white mb-3 tracking-tight">Dashboard Overview</h1>
+          <div className="w-24 h-1 bg-gradient-to-r from-indigo-400 to-purple-400 mx-auto rounded-full"></div>
+        </div>
+        {loading ? (
+          <div className="text-center py-20 text-slate-300">Loading orders...</div>
+        ) : (
+          <div className="space-y-10">
+            <section className={sectionClass}>
+              <h2 className="text-xl font-bold text-white mb-4">Orders Out Now</h2>
+              {ordersOut.length === 0 ? <p className="text-slate-400">None</p> : (
+                <ul className="space-y-3">
+                  {ordersOut.map(o => (
+                    <li key={o.id} className="bg-slate-700/50 p-4 rounded-lg">
+                      <div className="font-bold text-lg text-white">{o.customerName}</div>
+                      <p className="text-sm text-slate-400 mb-1">{o.pickUpDate} → {o.deliveryDate}</p>
+                      <p className="text-sm text-slate-300">Items: {o.items.map(it => `${it.itemName} x${it.quantity}`).join(', ')}</p>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </section>
+
+            <section className={sectionClass}>
+              <h2 className="text-xl font-bold text-white mb-4">Upcoming Pick-ups (next 5 days)</h2>
+              {upcomingOrders.length === 0 ? <p className="text-slate-400">None</p> : (
+                <ul className="space-y-3">
+                  {upcomingOrders.map(o => (
+                    <li key={o.id} className="bg-slate-700/50 p-4 rounded-lg">
+                      <div className="font-bold text-lg text-white">{o.customerName}</div>
+                      <p className="text-sm text-slate-400 mb-1">{o.pickUpDate} → {o.deliveryDate}</p>
+                      <p className="text-sm text-slate-300">Items: {o.items.map(it => `${it.itemName} x${it.quantity}`).join(', ')}</p>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </section>
+
+            <section className={sectionClass}>
+              <h2 className="text-xl font-bold text-white mb-4">Upcoming Returns (next 5 days)</h2>
+              {upcomingReturns.length === 0 ? <p className="text-slate-400">None</p> : (
+                <ul className="space-y-3">
+                  {upcomingReturns.map(o => (
+                    <li key={o.id} className="bg-slate-700/50 p-4 rounded-lg">
+                      <div className="font-bold text-lg text-white">{o.customerName}</div>
+                      <p className="text-sm text-slate-400 mb-1">{o.pickUpDate} → {o.deliveryDate}</p>
+                      <p className="text-sm text-slate-300">Items: {o.items.map(it => `${it.itemName} x${it.quantity}`).join(', ')}</p>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </section>
+          </div>
+        )}
+      </main>
+    </div>
+  );
+}

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -8,6 +8,7 @@ export default function Navbar() {
   const pathname = usePathname();
 
   const navItems = [
+    { href: '/dashboard', label: 'Dashboard' },
     { href: '/', label: 'Inventory' },
     { href: '/current-orders', label: 'Current Orders' },
     { href: '/packages', label: 'Packages' },


### PR DESCRIPTION
## Summary
- create new dashboard page summarizing orders out, upcoming pickups, and returns
- add phone and email fields to order form for better layout
- link dashboard in navigation

## Testing
- `npm run lint` *(fails: Unexpected any, unused vars)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6849d8c711b083278bb51d13f3e5c20e