### PR TITLE
Add order dashboard

### DIFF
--- a/src/app/current-orders/page.tsx
+++ b/src/app/current-orders/page.tsx
@@ -397,31 +397,20 @@ export default function CurrentOrdersPage() {
             <h1 className="text-4xl font-bold text-white mb-3 tracking-tight">Order Management</h1>
             <div className="w-24 h-1 bg-gradient-to-r from-indigo-400 to-purple-400 mx-auto rounded-full"></div>
           </div>
-          <div className="grid grid-cols-1 sm:grid-cols-3 gap-6 mb-8">
-            <div className="bg-slate-800/70 backdrop-blur-sm rounded-2xl p-4 border border-slate-700/50 shadow-lg flex items-center justify-between">
-              <p className="text-sm font-medium text-slate-400">Due Today</p>
-              <p className="text-2xl font-bold text-white">{ordersToday}</p>
-            </div>
-            <div className="bg-slate-800/70 backdrop-blur-sm rounded-2xl p-4 border border-slate-700/50 shadow-lg flex items-center justify-between">
-              <p className="text-sm font-medium text-slate-400">Due Tomorrow</p>
-              <p className="text-2xl font-bold text-white">{ordersTomorrow}</p>
-            </div>
-            <div className="bg-slate-800/70 backdrop-blur-sm rounded-2xl p-4 border border-slate-700/50 shadow-lg flex items-center justify-between">
-              <p className="text-sm font-medium text-slate-400">Next 7 Days</p>
-              <p className="text-2xl font-bold text-white">{ordersThisWeek}</p>
-            </div>
-          </div>
           <div className="grid grid-cols-1 xl:grid-cols-3 gap-8">
             <div className="xl:col-span-2 space-y-8">
               <div className="bg-slate-800/70 backdrop-blur-sm rounded-2xl border border-slate-700/50 shadow-2xl overflow-hidden">
                 <div className="px-6 py-4 border-b border-slate-700"><h2 className="text-xl font-bold text-white">{editingOrderId ? 'Edit Order' : 'Create New Order'}</h2></div>
                 <div className="p-6">
                   {/* Customer and Date Info */}
-                  <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-7 gap-6 mb-6">
+                  <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-6">
                     <div className="lg:col-span-2 space-y-2"><label htmlFor="customerName" className={labelStyle}>Customer Name</label><input id="customerName" className={inputStyle} value={customerName} onChange={e => setCustomerName(e.target.value)} placeholder="Enter name" /></div>
                     <div className="space-y-2"><label htmlFor="deposit" className={labelStyle}>Deposit (kr)</label><input id="deposit" className={inputStyle} value={deposit} onChange={e => setDeposit(e.target.value)} type="number" min={0} placeholder="0"/></div>
                     <div className="space-y-2"><label htmlFor="pickUpDate" className={labelStyle}>Pick-up Date</label><input id="pickUpDate" className={`${inputStyle} dark:[color-scheme:dark]`} type="date" value={pickUpDate} onChange={e => setPickUpDate(e.target.value)} /></div>
                     <div className="space-y-2"><label htmlFor="deliveryDate" className={labelStyle}>Delivery Date</label><input id="deliveryDate" className={`${inputStyle} dark:[color-scheme:dark]`} type="date" value={deliveryDate} onChange={e => setDeliveryDate(e.target.value)} /></div>
+                  </div>
+
+                  <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-6">
                     <div className="space-y-2"><label htmlFor="phone" className={labelStyle}>Phone</label><input id="phone" className={inputStyle} value={phone} onChange={e => setPhone(e.target.value)} placeholder="+47..." /></div>
                     <div className="space-y-2"><label htmlFor="email" className={labelStyle}>Email</label><input id="email" className={inputStyle} value={email} onChange={e => setEmail(e.target.value)} placeholder="name@example.com" /></div>
                   </div>

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,0 +1,168 @@
+'use client';
+import React, { useState, useEffect, useMemo } from 'react';
+
+interface OrderItemFromServer {
+  itemName: string | null;
+  quantity: number;
+  inventoryItem?: { name: string } | null;
+}
+
+interface OrderFromServer {
+  id: number;
+  customerName: string;
+  pickUpDate: string;
+  deliveryDate: string;
+  items: OrderItemFromServer[];
+}
+
+interface Order {
+  id: number;
+  customerName: string;
+  pickUpDate: string;
+  deliveryDate: string;
+  items: { itemName: string; quantity: number }[];
+}
+
+export default function DashboardPage() {
+  const [orders, setOrders] = useState<Order[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const res = await fetch('/api/orders');
+        const data: OrderFromServer[] = await res.json();
+        const mapped: Order[] = data.map(o => ({
+          id: o.id,
+          customerName: o.customerName,
+          pickUpDate: o.pickUpDate.slice(0, 10),
+          deliveryDate: o.deliveryDate.slice(0, 10),
+          items: o.items.map(i => ({
+            itemName: i.itemName || i.inventoryItem?.name || 'Deleted Item',
+            quantity: i.quantity,
+          })),
+        }));
+        setOrders(mapped);
+      } finally {
+        setLoading(false);
+      }
+    };
+    load();
+  }, []);
+
+  const today = useMemo(() => {
+    const d = new Date();
+    d.setHours(0, 0, 0, 0);
+    return d;
+  }, []);
+
+  const inFive = useMemo(() => {
+    const d = new Date(today);
+    d.setDate(d.getDate() + 5);
+    return d;
+  }, [today]);
+
+  const currentlyOut = useMemo(
+    () =>
+      orders.filter(o => {
+        const start = new Date(o.pickUpDate + 'T00:00:00');
+        const end = new Date(o.deliveryDate + 'T00:00:00');
+        return start <= today && end >= today;
+      }),
+    [orders, today]
+  );
+
+  const upcomingPickups = useMemo(
+    () =>
+      orders.filter(o => {
+        const start = new Date(o.pickUpDate + 'T00:00:00');
+        return start > today && start <= inFive;
+      }),
+    [orders, today, inFive]
+  );
+
+  const upcomingDeliveries = useMemo(
+    () =>
+      orders.filter(o => {
+        const end = new Date(o.deliveryDate + 'T00:00:00');
+        return end >= today && end <= inFive;
+      }),
+    [orders, today, inFive]
+  );
+
+  const renderOrder = (order: Order) => (
+    <div key={order.id} className="bg-slate-800/70 backdrop-blur-sm rounded-2xl p-4 border border-slate-700/50 shadow-lg">
+      <div className="flex flex-col sm:flex-row justify-between sm:items-center">
+        <div>
+          <h3 className="text-lg font-bold text-white">{order.customerName}</h3>
+          <p className="text-sm text-slate-400 mt-1">{order.pickUpDate} → {order.deliveryDate}</p>
+        </div>
+      </div>
+      <ul className="mt-2 text-sm text-slate-300 list-disc list-inside space-y-1">
+        {order.items.map((it, idx) => (
+          <li key={idx}>{it.itemName} × {it.quantity}</li>
+        ))}
+      </ul>
+    </div>
+  );
+
+  if (loading) {
+    return (
+      <div className="min-h-screen bg-gradient-to-br from-slate-900 via-indigo-900 to-purple-900 text-slate-200 flex items-center justify-center">
+        <div className="text-center">
+          <div className="inline-block animate-spin rounded-full h-12 w-12 border-b-2 border-slate-400 mb-4"></div>
+          <div className="text-xl text-slate-400 font-medium">Loading Dashboard...</div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-slate-900 via-indigo-900 to-purple-900 text-slate-200">
+      <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12 space-y-8">
+        <div className="text-center mb-12">
+          <h1 className="text-4xl font-bold text-white mb-3 tracking-tight">Dashboard</h1>
+          <div className="w-24 h-1 bg-gradient-to-r from-indigo-400 to-purple-400 mx-auto rounded-full"></div>
+        </div>
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+          <div className="bg-slate-800/70 backdrop-blur-sm rounded-2xl p-4 border border-slate-700/50 shadow-lg flex items-center justify-between">
+            <p className="text-sm font-medium text-slate-400">Currently Out</p>
+            <p className="text-2xl font-bold text-white">{currentlyOut.length}</p>
+          </div>
+          <div className="bg-slate-800/70 backdrop-blur-sm rounded-2xl p-4 border border-slate-700/50 shadow-lg flex items-center justify-between">
+            <p className="text-sm font-medium text-slate-400">Pick-ups Next 5 Days</p>
+            <p className="text-2xl font-bold text-white">{upcomingPickups.length}</p>
+          </div>
+          <div className="bg-slate-800/70 backdrop-blur-sm rounded-2xl p-4 border border-slate-700/50 shadow-lg flex items-center justify-between">
+            <p className="text-sm font-medium text-slate-400">Deliveries Next 5 Days</p>
+            <p className="text-2xl font-bold text-white">{upcomingDeliveries.length}</p>
+          </div>
+        </div>
+        {currentlyOut.length > 0 && (
+          <div>
+            <h2 className="text-2xl font-bold text-white mt-8 mb-4">Orders Currently Out</h2>
+            <div className="space-y-4">
+              {currentlyOut.map(renderOrder)}
+            </div>
+          </div>
+        )}
+        {upcomingPickups.length > 0 && (
+          <div>
+            <h2 className="text-2xl font-bold text-white mt-8 mb-4">Upcoming Pick-ups</h2>
+            <div className="space-y-4">
+              {upcomingPickups.map(renderOrder)}
+            </div>
+          </div>
+        )}
+        {upcomingDeliveries.length > 0 && (
+          <div>
+            <h2 className="text-2xl font-bold text-white mt-8 mb-4">Upcoming Deliveries</h2>
+            <div className="space-y-4">
+              {upcomingDeliveries.map(renderOrder)}
+            </div>
+          </div>
+        )}
+      </main>
+    </div>
+  );
+}

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -9,6 +9,7 @@ export default function Navbar() {
 
   const navItems = [
     { href: '/', label: 'Inventory' },
+    { href: '/dashboard', label: 'Dashboard' },
     { href: '/current-orders', label: 'Current Orders' },
     { href: '/packages', label: 'Packages' },
     { href: '/orders', label: 'Order Details' },


### PR DESCRIPTION
## Summary
- create Dashboard page for quick overview of current and upcoming orders
- link Dashboard in navbar
- tweak Current Orders form to put phone and email on their own row and remove the due‑date cards

## Testing
- `npx next lint` *(fails: Unexpected any and unused vars)*

------
https://chatgpt.com/codex/tasks/task_e_6849d96f73388327ae4ceeb8e19f8e3c