### PR TITLE
Implement requested dashboard and PDF fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "hasInstallScript": true,
       "dependencies": {
+        "@heroicons/react": "^2.2.0",
         "@prisma/client": "^6.9.0",
         "chart.js": "^4.4.9",
         "jspdf": "^3.0.1",
@@ -267,6 +268,15 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@heroicons/react": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@heroicons/react/-/react-2.2.0.tgz",
+      "integrity": "sha512-LMcepvRaS9LYHJGsF0zzmgKCUim/X3N/DQKc4jepAXJ7l8QxJ1PmxJzqplF2Z3FE4PqBAIGyJAQ/w4B5dsqbtQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">= 16 || ^19.0.0-rc"
       }
     },
     "node_modules/@humanfs/core": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "postinstall": "prisma generate && prisma migrate deploy"
   },
   "dependencies": {
+    "@heroicons/react": "^2.2.0",
     "@prisma/client": "^6.9.0",
     "chart.js": "^4.4.9",
     "jspdf": "^3.0.1",

--- a/src/app/current-orders/page.tsx
+++ b/src/app/current-orders/page.tsx
@@ -404,7 +404,7 @@ export default function CurrentOrdersPage() {
                 <div className="p-6">
                   {/* Customer and Date Info */}
                   <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-6">
-                    <div className="lg:col-span-2 space-y-2"><label htmlFor="customerName" className={labelStyle}>Customer Name</label><input id="customerName" autoComplete="off" className={inputStyle} value={customerName} onChange={e => setCustomerName(e.target.value)} placeholder="Enter name" /></div>
+                    <div className="lg:col-span-2 space-y-2"><label htmlFor="customerName" className={labelStyle}>Customer Name</label><input id="customerName" autoComplete="new-password" autoCorrect="off" spellCheck={false} className={inputStyle} value={customerName} onChange={e => setCustomerName(e.target.value)} placeholder="Enter name" /></div>
                     <div className="space-y-2"><label htmlFor="deposit" className={labelStyle}>Deposit (kr)</label><input id="deposit" className={inputStyle} value={deposit} onChange={e => setDeposit(e.target.value)} type="number" min={0} placeholder="0"/></div>
                   </div>
 
@@ -414,8 +414,8 @@ export default function CurrentOrdersPage() {
                   </div>
 
                   <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-6">
-                    <div className="space-y-2"><label htmlFor="phone" className={labelStyle}>Phone</label><input id="phone" autoComplete="off" className={inputStyle} value={phone} onChange={e => setPhone(e.target.value)} placeholder="+47..." /></div>
-                    <div className="lg:col-span-2 space-y-2"><label htmlFor="email" className={labelStyle}>Email</label><input id="email" autoComplete="off" className={inputStyle} value={email} onChange={e => setEmail(e.target.value)} placeholder="name@example.com" /></div>
+                    <div className="space-y-2"><label htmlFor="phone" className={labelStyle}>Phone</label><input id="phone" autoComplete="new-password" autoCorrect="off" spellCheck={false} className={inputStyle} value={phone} onChange={e => setPhone(e.target.value)} placeholder="+47..." /></div>
+                    <div className="lg:col-span-2 space-y-2"><label htmlFor="email" className={labelStyle}>Email</label><input id="email" autoComplete="new-password" autoCorrect="off" spellCheck={false} className={inputStyle} value={email} onChange={e => setEmail(e.target.value)} placeholder="name@example.com" /></div>
                   </div>
                   
                   <div className="mt-4 border-t border-slate-700 pt-4 grid grid-cols-1 md:grid-cols-2 gap-x-8 gap-y-6">

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -84,8 +84,9 @@ export default function DashboardPage() {
   const upcomingDeliveries = useMemo(
     () =>
       orders.filter(o => {
+        const start = new Date(o.pickUpDate + 'T00:00:00');
         const end = new Date(o.deliveryDate + 'T00:00:00');
-        return end >= today && end <= inFive;
+        return start <= today && end >= today && end <= inFive;
       }),
     [orders, today, inFive]
   );

--- a/src/app/orders/page.tsx
+++ b/src/app/orders/page.tsx
@@ -242,7 +242,7 @@ export default function OrderDetailsPage() {
     doc.text(`${T.depositPayment}: ${formatCurrency(selectedOrder.deposit)}`, 14, y);
     y += 7;
     if (depositDeadline) {
-      doc.text(`${T.deadlineForDeposit}: ${depositDeadline}`, 14, y);
+      doc.text(`${T.deadlineForDeposit}: ${formatPdfDate(depositDeadline)}`, 14, y);
       y += 7;
     }
 

--- a/src/app/orders/page.tsx
+++ b/src/app/orders/page.tsx
@@ -263,7 +263,11 @@ export default function OrderDetailsPage() {
       doc.text(`${idx + 1}. ${T[key]}`, 16, y + idx * 6);
     });
 
-    doc.save(`order_${selectedOrder.id}.pdf`);
+    const fileName =
+      language === 'en'
+        ? `order details to ${selectedOrder.customerName}.pdf`
+        : `ordredetaljer til ${selectedOrder.customerName}.pdf`;
+    doc.save(fileName);
   };
 
   return (

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -3,9 +3,12 @@
 
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
+import { useState } from 'react';
+import { Bars3Icon, XMarkIcon } from '@heroicons/react/24/outline';
 
 export default function Navbar() {
   const pathname = usePathname();
+  const [open, setOpen] = useState(false);
 
   const navItems = [
     { href: '/dashboard', label: 'Dashboard' },
@@ -18,14 +21,22 @@ export default function Navbar() {
   ];
 
   return (
-    <nav className="bg-slate-900/80 backdrop-blur-sm shadow-md sticky top-0 z-40 border-b border-slate-700/50">
+    <nav className="bg-slate-800/90 backdrop-blur-md shadow-md sticky top-0 z-40 border-b border-slate-700/50">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-        <div className="flex items-center justify-center h-16">
-          <div className="flex items-center space-x-4">
+        <div className="flex items-center justify-between h-16">
+          <button
+            className="md:hidden p-2 text-slate-300 hover:text-white"
+            aria-label="Toggle navigation"
+            onClick={() => setOpen(!open)}
+          >
+            {open ? <XMarkIcon className="w-6 h-6" /> : <Bars3Icon className="w-6 h-6" />}
+          </button>
+          <div className="hidden md:flex items-center space-x-4">
             {navItems.map((item) => (
               <Link
                 key={item.href}
                 href={item.href}
+                onClick={() => setOpen(false)}
                 className={`px-3 py-2 rounded-md text-sm font-semibold transition-colors duration-200 ${
                   pathname === item.href
                     ? 'bg-indigo-600 text-white shadow'
@@ -37,6 +48,24 @@ export default function Navbar() {
             ))}
           </div>
         </div>
+        {open && (
+          <div className="flex flex-col space-y-1 pb-4 md:hidden">
+            {navItems.map((item) => (
+              <Link
+                key={item.href}
+                href={item.href}
+                onClick={() => setOpen(false)}
+                className={`px-3 py-2 rounded-md text-sm font-semibold transition-colors duration-200 ${
+                  pathname === item.href
+                    ? 'bg-indigo-600 text-white shadow'
+                    : 'text-slate-300 hover:bg-slate-700/50 hover:text-white'
+                }`}
+              >
+                {item.label}
+              </Link>
+            ))}
+          </div>
+        )}
       </div>
     </nav>
   );


### PR DESCRIPTION
## Summary
- name order detail PDFs using customer name
- filter upcoming deliveries so only active orders count
- disable browser autofill for customer contact fields

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a1982510c8327b12e03669bf52e70