### PR TITLE
Format dates consistently and update navbar style

### DIFF
--- a/src/app/completed-orders/page.tsx
+++ b/src/app/completed-orders/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 import React, { useState, useEffect, useCallback } from 'react';
 import { toast } from 'sonner';
+import { formatDate } from '@/lib/date';
 
 // --- Types ---
 type OrderItemFromServer = {
@@ -76,8 +77,8 @@ export default function CompletedOrdersPage() {
       const contactData = loadContactInfo();
       const mappedOrders = ordersData.map((order: any) => ({
         ...order,
-        pickUpDate: new Date(order.pickUpDate).toLocaleDateString('nb-NO'),
-        deliveryDate: new Date(order.deliveryDate).toLocaleDateString('nb-NO'),
+        pickUpDate: formatDate(order.pickUpDate),
+        deliveryDate: formatDate(order.deliveryDate),
         items: order.items.map((item: OrderItemFromServer) => ({
           // --- THIS IS THE KEY CHANGE ---
           // 1. Use the snapped `itemName` if it exists.

--- a/src/app/current-orders/page.tsx
+++ b/src/app/current-orders/page.tsx
@@ -1,5 +1,7 @@
 'use client';
 import React, { useState, useMemo, useEffect, useCallback } from 'react';
+import { formatDate } from '@/lib/date';
+import { getPickupDateStyles } from '@/lib/pickupColors';
 import { toast } from 'sonner';
 
 // --- Types ---
@@ -47,25 +49,6 @@ const saveContactInfo = (info: Record<number, { phone: string; email: string }>)
   if (typeof window !== 'undefined') {
     localStorage.setItem('orderContactInfo', JSON.stringify(info));
   }
-};
-
-// --- HELPER FUNCTION for Date Color-Coding ---
-const getPickupDateStyles = (dateStr: string): { bg: string; text: string } => {
-  if (!dateStr) return { bg: 'bg-transparent', text: 'text-slate-500' };
-  const today = new Date(); today.setHours(0, 0, 0, 0);
-  const pickupDate = new Date(dateStr + 'T00:00:00'); pickupDate.setHours(0, 0, 0, 0);
-  const diffTime = pickupDate.getTime() - today.getTime();
-  const daysUntilPickup = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
-
-  if (daysUntilPickup <= 0) return { bg: 'bg-red-600', text: 'text-white' };
-  if (daysUntilPickup === 1) return { bg: 'bg-orange-600', text: 'text-white' };
-  if (daysUntilPickup === 2) return { bg: 'bg-orange-400', text: 'text-slate-800' };
-  if (daysUntilPickup === 3) return { bg: 'bg-yellow-400', text: 'text-slate-800' };
-  if (daysUntilPickup === 4) return { bg: 'bg-orange-200', text: 'text-slate-800' };
-  if (daysUntilPickup === 5) return { bg: 'bg-green-200', text: 'text-slate-800' };
-  if (daysUntilPickup === 6) return { bg: 'bg-green-300', text: 'text-slate-800' };
-  if (daysUntilPickup >= 7) return { bg: 'bg-green-500', text: 'text-white' };
-  return { bg: 'bg-transparent', text: 'text-slate-500' };
 };
 
 // --- HELPER FUNCTION for Currency ---
@@ -502,10 +485,10 @@ export default function CurrentOrdersPage() {
                                     {order.email && <span>{order.email}</span>}
                                   </p>
                                 )}
-                              <div className="flex items-center gap-2 text-base font-bold mt-1">
-                                  <span className={`px-2 py-0.5 rounded-md transition-colors ${pickupStyles.bg} ${pickupStyles.text}`}>{new Date(order.pickUpDate + 'T00:00:00').toLocaleDateString()}</span>
+                                <div className="flex items-center gap-2 text-base font-bold mt-1">
+                                  <span className={`px-2 py-0.5 rounded-md transition-colors ${pickupStyles.bg} ${pickupStyles.text}`}>{formatDate(order.pickUpDate)}</span>
                                   <span className="text-slate-500">→</span>
-                                  <span className="text-slate-400">{new Date(order.deliveryDate + 'T00:00:00').toLocaleDateString()}</span>
+                                  <span className="text-slate-400">{formatDate(order.deliveryDate)}</span>
                                 </div>
                               </div>
                               <div className="text-left sm:text-right mt-2 sm:mt-0">

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,5 +1,7 @@
 'use client';
 import React, { useState, useEffect, useMemo } from 'react';
+import { formatDate } from '@/lib/date';
+import { getPickupDateStyles } from '@/lib/pickupColors';
 
 interface OrderItemFromServer {
   itemName: string | null;
@@ -91,21 +93,28 @@ export default function DashboardPage() {
     [orders, today, inFive]
   );
 
-  const renderOrder = (order: Order) => (
-    <div key={order.id} className="bg-slate-800/70 backdrop-blur-sm rounded-2xl p-4 border border-slate-700/50 shadow-lg">
-      <div className="flex flex-col sm:flex-row justify-between sm:items-center">
-        <div>
-          <h3 className="text-lg font-bold text-white">{order.customerName}</h3>
-          <p className="text-sm text-slate-400 mt-1">{order.pickUpDate} → {order.deliveryDate}</p>
+  const renderOrder = (order: Order) => {
+    const pickupStyles = getPickupDateStyles(order.pickUpDate);
+    return (
+      <div key={order.id} className="bg-slate-800/70 backdrop-blur-sm rounded-2xl p-4 border border-slate-700/50 shadow-lg">
+        <div className="flex flex-col sm:flex-row justify-between sm:items-center">
+          <div>
+            <h3 className="text-lg font-bold text-white">{order.customerName}</h3>
+            <div className="flex items-center gap-2 text-sm font-bold mt-1">
+              <span className={`px-2 py-0.5 rounded-md ${pickupStyles.bg} ${pickupStyles.text}`}>{formatDate(order.pickUpDate)}</span>
+              <span className="text-slate-500">→</span>
+              <span className="text-slate-400">{formatDate(order.deliveryDate)}</span>
+            </div>
+          </div>
         </div>
+        <ul className="mt-2 text-sm text-slate-300 list-disc list-inside space-y-1">
+          {order.items.map((it, idx) => (
+            <li key={idx}>{it.itemName} × {it.quantity}</li>
+          ))}
+        </ul>
       </div>
-      <ul className="mt-2 text-sm text-slate-300 list-disc list-inside space-y-1">
-        {order.items.map((it, idx) => (
-          <li key={idx}>{it.itemName} × {it.quantity}</li>
-        ))}
-      </ul>
-    </div>
-  );
+    );
+  };
 
   if (loading) {
     return (

--- a/src/app/orders/page.tsx
+++ b/src/app/orders/page.tsx
@@ -110,14 +110,13 @@ const formatCurrency = (amount: number | null | undefined) => {
   return `${formattedAmount} kr`;
 };
 
-const formatDisplayDate = (dateString: string, locale: 'en' | 'no') => {
+const formatDisplayDate = (dateString: string) => {
   if (!dateString) return '';
   const date = new Date(dateString);
-  return new Intl.DateTimeFormat(locale === 'no' ? 'nb-NO' : 'en-US', {
-    year: 'numeric',
-    month: 'long',
-    day: 'numeric',
-  }).format(date);
+  const dd = String(date.getDate()).padStart(2, '0');
+  const mm = String(date.getMonth() + 1).padStart(2, '0');
+  const yyyy = date.getFullYear();
+  return `${dd}/${mm}/${yyyy}`;
 };
 
 export default function OrderDetailsPage() {
@@ -313,8 +312,8 @@ export default function OrderDetailsPage() {
             <div className="bg-slate-800 p-4 border-b border-slate-700"><h2 className="text-xl font-bold text-slate-100 text-center">{T.orderDetailsFor} {selectedOrder.customerName}</h2></div>
             <div className="p-4 sm:p-6">
               <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-6">
-                <div className="bg-slate-800 p-4 rounded-lg border border-slate-700"><div className="flex items-center"><div className="w-9 h-9 bg-slate-700 rounded-md flex items-center justify-center mr-3"><svg className="w-5 h-5 text-slate-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"></path></svg></div><div><p className="text-xs font-bold text-slate-400 uppercase tracking-wider">{T.pickUpDate}</p><p className="text-sm font-bold text-slate-100">{formatDisplayDate(selectedOrder.pickUpDate, language)}</p></div></div></div>
-                <div className="bg-slate-800 p-4 rounded-lg border border-slate-700"><div className="flex items-center"><div className="w-9 h-9 bg-slate-700 rounded-md flex items-center justify-center mr-3"><svg className="w-5 h-5 text-slate-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4"></path></svg></div><div><p className="text-xs font-bold text-slate-400 uppercase tracking-wider">{T.deliveryDate}</p><p className="text-sm font-bold text-slate-100">{formatDisplayDate(selectedOrder.deliveryDate, language)}</p></div></div></div>
+              <div className="bg-slate-800 p-4 rounded-lg border border-slate-700"><div className="flex items-center"><div className="w-9 h-9 bg-slate-700 rounded-md flex items-center justify-center mr-3"><svg className="w-5 h-5 text-slate-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"></path></svg></div><div><p className="text-xs font-bold text-slate-400 uppercase tracking-wider">{T.pickUpDate}</p><p className="text-sm font-bold text-slate-100">{formatDisplayDate(selectedOrder.pickUpDate)}</p></div></div></div>
+              <div className="bg-slate-800 p-4 rounded-lg border border-slate-700"><div className="flex items-center"><div className="w-9 h-9 bg-slate-700 rounded-md flex items-center justify-center mr-3"><svg className="w-5 h-5 text-slate-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4"></path></svg></div><div><p className="text-xs font-bold text-slate-400 uppercase tracking-wider">{T.deliveryDate}</p><p className="text-sm font-bold text-slate-100">{formatDisplayDate(selectedOrder.deliveryDate)}</p></div></div></div>
               </div>
               
               <div className="mb-6">

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -21,11 +21,11 @@ export default function Navbar() {
   ];
 
   return (
-    <nav className="bg-slate-800/90 backdrop-blur-md shadow-md sticky top-0 z-40 border-b border-slate-700/50">
+    <nav className="bg-gradient-to-r from-indigo-800 via-purple-800 to-fuchsia-800/90 backdrop-blur-md shadow-md sticky top-0 z-40 border-b border-slate-700/50">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-        <div className="flex items-center justify-between h-16">
+        <div className="relative flex items-center justify-center h-16">
           <button
-            className="md:hidden p-2 text-slate-300 hover:text-white"
+            className="absolute left-0 md:hidden p-2 text-slate-300 hover:text-white"
             aria-label="Toggle navigation"
             onClick={() => setOpen(!open)}
           >

--- a/src/lib/date.ts
+++ b/src/lib/date.ts
@@ -1,0 +1,8 @@
+export const formatDate = (dateStr: string): string => {
+  if (!dateStr) return '';
+  const d = new Date(dateStr);
+  const dd = String(d.getDate()).padStart(2, '0');
+  const mm = String(d.getMonth() + 1).padStart(2, '0');
+  const yyyy = d.getFullYear();
+  return `${dd}/${mm}/${yyyy}`;
+};

--- a/src/lib/pickupColors.ts
+++ b/src/lib/pickupColors.ts
@@ -1,0 +1,19 @@
+export const getPickupDateStyles = (dateStr: string): { bg: string; text: string } => {
+  if (!dateStr) return { bg: 'bg-transparent', text: 'text-slate-500' };
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  const pickupDate = new Date(dateStr + 'T00:00:00');
+  pickupDate.setHours(0, 0, 0, 0);
+  const diffTime = pickupDate.getTime() - today.getTime();
+  const daysUntilPickup = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
+
+  if (daysUntilPickup <= 0) return { bg: 'bg-red-600', text: 'text-white' };
+  if (daysUntilPickup === 1) return { bg: 'bg-orange-600', text: 'text-white' };
+  if (daysUntilPickup === 2) return { bg: 'bg-orange-400', text: 'text-slate-800' };
+  if (daysUntilPickup === 3) return { bg: 'bg-yellow-400', text: 'text-slate-800' };
+  if (daysUntilPickup === 4) return { bg: 'bg-orange-200', text: 'text-slate-800' };
+  if (daysUntilPickup === 5) return { bg: 'bg-green-200', text: 'text-slate-800' };
+  if (daysUntilPickup === 6) return { bg: 'bg-green-300', text: 'text-slate-800' };
+  if (daysUntilPickup >= 7) return { bg: 'bg-green-500', text: 'text-white' };
+  return { bg: 'bg-transparent', text: 'text-slate-500' };
+};


### PR DESCRIPTION
## Summary
- add `formatDate` helper and `getPickupDateStyles`
- use new helpers in dashboard, current orders, completed orders
- standardize order details date formatting
- modernize and center the navbar

## Testing
- `npm run lint` *(fails: Unexpected any, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_684a22ae8f748327a58275674c85f813