### PR TITLE
Implement dashboard reminder and color tweaks

### DIFF
--- a/src/lib/pickupColors.ts
+++ b/src/lib/pickupColors.ts
@@ -20,7 +20,7 @@ export const getPickupDateStyles = (
 
   // Today or tomorrow
   if (daysUntilPickup <= 1) {
-    return { bg: 'bg-red-600', text: 'text-white' };
+    return { bg: 'bg-red-800', text: 'text-white' };
   }
 
   // 2-4 days away


### PR DESCRIPTION
## Summary
- tweak urgency red in helper
- update expected revenue label
- sort upcoming pickups
- add ready-items reminder box
- disable color-coding in dashboard deliveries

## Testing
- `npm install --ignore-scripts`
- `npm run lint` *(fails: Unexpected any, unused vars)*

------
https://chatgpt.com/codex/tasks/task_e_684a36570b8c832796f1ad48dfb53761