### PR TITLE
Remove edit buttons and update stats

### DIFF
--- a/src/app/current-orders/page.tsx
+++ b/src/app/current-orders/page.tsx
@@ -510,9 +510,29 @@ export default function CurrentOrdersPage() {
                               </table>
                             </div>
                             <div className="flex items-center gap-2 pt-4 border-t border-slate-700">
-                              <button onClick={() => handleEditOrder(order)} disabled={!!processingOrderId} className="px-4 py-2 text-base font-bold text-indigo-300 bg-indigo-900/50 hover:bg-indigo-900/80 rounded-lg transition-all shadow-sm disabled:opacity-50 disabled:cursor-not-allowed">Edit</button>
-                              <button onClick={() => handleDeleteOrder(order.id)} disabled={!!processingOrderId} className="px-4 py-2 text-base font-bold text-red-300 bg-red-900/50 hover:bg-red-900/80 rounded-lg transition-all shadow-sm disabled:opacity-50 disabled:cursor-not-allowed">Delete</button>
-                              <div className="ml-auto">{processingOrderId === order.id ? (<div className="px-4 py-2 flex items-center gap-2 text-base font-bold text-white"><div className="w-4 h-4 border-2 border-white/50 border-t-white rounded-full animate-spin"></div>Processing...</div>) : (<button onClick={() => handleCompleteOrder(order.id)} disabled={!!processingOrderId} className="px-4 py-2 text-base font-bold text-white bg-gradient-to-r from-emerald-500 to-green-600 rounded-lg shadow-md hover:shadow-lg disabled:opacity-50 disabled:cursor-not-allowed">Mark as Completed</button>)}</div>
+                              <button
+                                onClick={() => handleDeleteOrder(order.id)}
+                                disabled={!!processingOrderId}
+                                className="px-4 py-2 text-base font-bold text-red-300 bg-red-900/50 hover:bg-red-900/80 rounded-lg transition-all shadow-sm disabled:opacity-50 disabled:cursor-not-allowed"
+                              >
+                                Delete
+                              </button>
+                              <div className="ml-auto">
+                                {processingOrderId === order.id ? (
+                                  <div className="px-4 py-2 flex items-center gap-2 text-base font-bold text-white">
+                                    <div className="w-4 h-4 border-2 border-white/50 border-t-white rounded-full animate-spin"></div>
+                                    Processing...
+                                  </div>
+                                ) : (
+                                  <button
+                                    onClick={() => handleCompleteOrder(order.id)}
+                                    disabled={!!processingOrderId}
+                                    className="px-4 py-2 text-base font-bold text-white bg-gradient-to-r from-emerald-500 to-green-600 rounded-lg shadow-md hover:shadow-lg disabled:opacity-50 disabled:cursor-not-allowed"
+                                  >
+                                    Mark as Completed
+                                  </button>
+                                )}
+                              </div>
                             </div>
                           </div>
                         )

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -251,9 +251,14 @@ export default function DashboardPage() {
           {upcomingPickups.length > 0 && (
             <div>
               {showReadyReminder && nextPickup && (
-                <div className="mb-4 p-4 bg-indigo-900/60 border border-indigo-700 rounded-xl flex items-center justify-between shadow-lg">
-                  <p className="text-sm font-medium text-indigo-200">Have you remembered to ready the items for {nextPickup.customerName}?</p>
-                  <button onClick={() => dismissReminder(nextPickup.id)} className="ml-4 px-3 py-1 bg-indigo-700 rounded-md text-white font-bold">Yes</button>
+                <div className="mb-4 p-4 bg-gradient-to-r from-indigo-700 via-purple-700 to-fuchsia-700 border border-indigo-700 rounded-xl flex items-center justify-between shadow-lg">
+                  <p className="text-lg font-bold text-white">Have you remembered to ready the items for {nextPickup.customerName}?</p>
+                  <button
+                    onClick={() => dismissReminder(nextPickup.id)}
+                    className="ml-4 px-3 py-1 bg-indigo-600 rounded-md text-white font-bold"
+                  >
+                    Yes
+                  </button>
                 </div>
               )}
               <h2 className="text-2xl font-bold text-white mt-8 mb-4">Upcoming Pick-ups</h2>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -222,7 +222,16 @@ export default function Home() {
                     </td>
                     <td className="px-6 py-4 text-right text-slate-300 font-medium">{formatCurrency(item.pricePerItem)}</td>
                     <td className="px-6 py-4 text-right text-slate-300 font-medium">{formatCurrency(item.pricePaid)}</td>
-                    <td className="px-6 py-4"><div className="flex justify-center gap-2"><button onClick={() => handleEdit(item)} className="px-4 py-2 text-sm font-bold text-indigo-300 bg-indigo-900/50 hover:bg-indigo-900/80 rounded-lg transition-all shadow-sm">Edit</button><button onClick={() => handleDelete(item.id)} className="px-4 py-2 text-sm font-bold text-red-300 bg-red-900/50 hover:bg-red-900/80 rounded-lg transition-all shadow-sm">Delete</button></div></td>
+                    <td className="px-6 py-4">
+                      <div className="flex justify-center">
+                        <button
+                          onClick={() => handleDelete(item.id)}
+                          className="px-4 py-2 text-sm font-bold text-red-300 bg-red-900/50 hover:bg-red-900/80 rounded-lg transition-all shadow-sm"
+                        >
+                          Delete
+                        </button>
+                      </div>
+                    </td>
                   </tr>
                 ))}
               </tbody>

--- a/src/app/statistics/page.tsx
+++ b/src/app/statistics/page.tsx
@@ -83,12 +83,24 @@ export default function StatisticsPage() {
     if (!sortedSalesByItem || sortedSalesByItem.length === 0) {
         return { labels: [], datasets: [] };
     }
-    const topItems = sortedSalesByItem.slice(0, 7);
-    const otherSales = sortedSalesByItem.slice(7).reduce((sum, item) => sum + item.totalSales, 0);
+    const topItems = sortedSalesByItem.slice(0, 10);
+    const otherSales = sortedSalesByItem.slice(10).reduce((sum, item) => sum + item.totalSales, 0);
     const itemNames = topItems.map(item => item.itemName);
     const itemSales = topItems.map(item => item.totalSales);
     if (otherSales > 0) { itemNames.push('Other'); itemSales.push(otherSales); }
-    const backgroundColors = ['#f59e0b', '#14b8a6', '#0ea5e9', '#a78bfa', '#f472b6', '#84cc16', '#64748b'];
+    const backgroundColors = [
+      '#f59e0b',
+      '#14b8a6',
+      '#0ea5e9',
+      '#a78bfa',
+      '#f472b6',
+      '#84cc16',
+      '#64748b',
+      '#ef4444',
+      '#eab308',
+      '#8b5cf6',
+      '#374151',
+    ];
     return { labels: itemNames, datasets: [{ label: 'Sales by Item', data: itemSales, backgroundColor: backgroundColors, borderColor: '#1e293b', borderWidth: 2 }], };
   }, [sortedSalesByItem]);
 
@@ -212,7 +224,7 @@ export default function StatisticsPage() {
           </div>
         </div>
         
-        <div className="grid grid-cols-1 lg:grid-cols-5 gap-8">
+        <div className="grid grid-cols-1 lg:grid-cols-6 gap-8">
           <div className="lg:col-span-3 bg-slate-800/90 backdrop-blur-sm rounded-2xl border border-slate-700/50 shadow-xl p-6">
             <div className="flex justify-between items-center mb-4">
               <h2 className="text-xl font-semibold text-slate-200">Monthly Sales</h2>
@@ -231,7 +243,7 @@ export default function StatisticsPage() {
               <Line data={monthlySalesData} options={chartOptions} />
             </div>
           </div>
-          <div className="lg:col-span-2 bg-slate-800/90 backdrop-blur-sm rounded-2xl border border-slate-700/50 shadow-xl p-6">
+          <div className="lg:col-span-3 bg-slate-800/90 backdrop-blur-sm rounded-2xl border border-slate-700/50 shadow-xl p-6">
             <h2 className="text-xl font-semibold text-slate-200 text-center mb-4">Sales Distribution</h2>
             <div className="h-80 flex justify-center items-center">
               <Pie data={pieChartData} options={{...chartOptions, plugins: { legend: { position: 'right' as const, display: true, labels: { color: '#e2e8f0' } }}}}/>


### PR DESCRIPTION
## Summary
- remove Edit buttons from inventory and current order pages
- show top 10 items in statistics pie chart and expand layout
- highlight the dashboard ready reminder

## Testing
- `npm run lint` *(fails: unexpected any and unused vars)*

------
https://chatgpt.com/codex/tasks/task_e_684a3a23b8148327848d28e395cf2654