### PR TITLE
Update package creation and inventory views

### DIFF
--- a/src/app/api/inventory/route.ts
+++ b/src/app/api/inventory/route.ts
@@ -12,11 +12,14 @@ export async function GET() {
       orderBy: { name: 'asc' }, // Order alphabetically by name
     });
 
-    // 2. Fetch all order items from ACTIVE (not completed) orders
+    // 2. Fetch all order items that are currently rented out
+    const today = new Date();
     const activeOrderItems = await prisma.orderItem.findMany({
       where: {
         order: {
           completed: false,
+          pickUpDate: { lte: today },
+          deliveryDate: { gte: today },
         },
       },
     });
@@ -24,8 +27,6 @@ export async function GET() {
     // 3. Calculate the total rented out quantity for each item
     const rentedOutMap = new Map<number, number>();
     for (const orderItem of activeOrderItems) {
-      // --- THIS IS THE FIX ---
-      // Only process items that are still linked to an inventory item
       if (orderItem.inventoryItemId !== null) {
         const currentRented = rentedOutMap.get(orderItem.inventoryItemId) || 0;
         rentedOutMap.set(orderItem.inventoryItemId, currentRented + orderItem.quantity);

--- a/src/app/packages/page.tsx
+++ b/src/app/packages/page.tsx
@@ -104,6 +104,15 @@ export default function PackagesPage() {
             toast.error('Package name and at least one item are required.');
             return;
         }
+
+        for (const pi of packageItems) {
+            const inv = inventory.find(it => it.id === pi.inventoryItem.id);
+            if (inv && pi.quantity > inv.totalQuantity) {
+                toast.error(`Not enough '${inv.name}' in inventory to create this package.`);
+                return;
+            }
+        }
+
         setIsProcessing(true);
         try {
             const payload = {
@@ -278,15 +287,48 @@ export default function PackagesPage() {
                     <div className={`space-y-6 ${cardStyle}`}>
                         <h2 className="text-2xl font-bold text-white">Create Order from Package</h2>
                         <div className="space-y-4">
-                            <div><label htmlFor="customer" className={labelStyle}>Customer Name</label><input id="customer" value={customerName} onChange={(e) => setCustomerName(e.target.value)} className={inputStyle} /></div>
+                            <div>
+                                <label htmlFor="customer" className={labelStyle}>Customer Name</label>
+                                <input
+                                    id="customer"
+                                    value={customerName}
+                                    onChange={(e) => setCustomerName(e.target.value)}
+                                    className={inputStyle}
+                                    autoComplete="new-password"
+                                    autoCorrect="off"
+                                    spellCheck={false}
+                                />
+                            </div>
                             <div className="grid grid-cols-2 gap-4">
                                 <div><label htmlFor="pickup" className={labelStyle}>Pick-up Date</label><input id="pickup" type="date" value={pickUpDate} onChange={(e) => setPickUpDate(e.target.value)} className={`${inputStyle} dark:[color-scheme:dark]`} /></div>
                                 <div><label htmlFor="delivery" className={labelStyle}>Delivery Date</label><input id="delivery" type="date" value={deliveryDate} onChange={(e) => setDeliveryDate(e.target.value)} className={`${inputStyle} dark:[color-scheme:dark]`} /></div>
                             </div>
                             <div><label htmlFor="deposit" className={labelStyle}>Deposit (kr)</label><input id="deposit" type="number" min={0} value={deposit} onChange={(e) => setDeposit(e.target.value)} className={inputStyle} /></div>
                             <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                                <div><label htmlFor="phone" className={labelStyle}>Phone</label><input id="phone" value={phone} onChange={(e) => setPhone(e.target.value)} className={inputStyle} /></div>
-                                <div><label htmlFor="email" className={labelStyle}>Email</label><input id="email" value={email} onChange={(e) => setEmail(e.target.value)} className={inputStyle} /></div>
+                                <div>
+                                    <label htmlFor="phone" className={labelStyle}>Phone</label>
+                                    <input
+                                        id="phone"
+                                        value={phone}
+                                        onChange={(e) => setPhone(e.target.value)}
+                                        className={inputStyle}
+                                        autoComplete="new-password"
+                                        autoCorrect="off"
+                                        spellCheck={false}
+                                    />
+                                </div>
+                                <div>
+                                    <label htmlFor="email" className={labelStyle}>Email</label>
+                                    <input
+                                        id="email"
+                                        value={email}
+                                        onChange={(e) => setEmail(e.target.value)}
+                                        className={inputStyle}
+                                        autoComplete="new-password"
+                                        autoCorrect="off"
+                                        spellCheck={false}
+                                    />
+                                </div>
                             </div>
                             <div className="relative">
                                 <label htmlFor="package-search" className={labelStyle}>Select Package</label>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -210,7 +210,17 @@ export default function Home() {
           </div>
           <div className="overflow-x-auto">
             <table className="w-full">
-              <thead className="bg-slate-800/50"><tr className="border-b border-slate-700"><th className="px-6 py-4 text-left text-xs font-semibold text-slate-400 uppercase tracking-wider">Item Name</th><th className="px-6 py-4 text-center text-xs font-semibold text-slate-400 uppercase tracking-wider">Total</th><th className="px-6 py-4 text-center text-xs font-semibold text-slate-400 uppercase tracking-wider">Rented</th><th className="px-6 py-4 text-center text-xs font-semibold text-slate-400 uppercase tracking-wider">In Stock</th><th className="px-6 py-4 text-right text-xs font-semibold text-slate-400 uppercase tracking-wider">Price per Item</th><th className="px-6 py-4 text-right text-xs font-semibold text-slate-400 uppercase tracking-wider">Price Paid for Single Item</th><th className="px-6 py-4 text-center text-xs font-semibold text-slate-400 uppercase tracking-wider">Actions</th></tr></thead>
+              <thead className="bg-slate-800/50">
+                <tr className="border-b border-slate-700">
+                  <th className="px-6 py-4 text-left text-xs font-semibold text-slate-400 uppercase tracking-wider">Item Name</th>
+                  <th className="px-6 py-4 text-center text-xs font-semibold text-slate-400 uppercase tracking-wider">Total Quantity</th>
+                  <th className="px-6 py-4 text-center text-xs font-semibold text-slate-400 uppercase tracking-wider">Rented Now</th>
+                  <th className="px-6 py-4 text-center text-xs font-semibold text-slate-400 uppercase tracking-wider">In Stock Now</th>
+                  <th className="px-6 py-4 text-right text-xs font-semibold text-slate-400 uppercase tracking-wider">Price per Item</th>
+                  <th className="px-6 py-4 text-right text-xs font-semibold text-slate-400 uppercase tracking-wider">Price Paid for Single Item</th>
+                  <th className="px-6 py-4 text-center text-xs font-semibold text-slate-400 uppercase tracking-wider">Actions</th>
+                </tr>
+              </thead>
               <tbody className="divide-y divide-slate-700/50">
                 {filteredItems.map((item, index) => (
                   <tr key={item.id} className="hover:bg-slate-700/40 transition-colors duration-200">


### PR DESCRIPTION
## Summary
- disable browser autofill for customer contact fields on package order form
- validate package templates against available inventory quantities
- show only currently rented items in inventory API
- rename quantity headers on inventory page

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684ae93754bc83278e5c164dd5e08bf6